### PR TITLE
fix: Correct logging and remove dead code

### DIFF
--- a/src/x_agent/agents/unblock_agent.py
+++ b/src/x_agent/agents/unblock_agent.py
@@ -140,12 +140,3 @@ class UnblockAgent(BaseAgent):
                 f"Failed to unblock {len(failed_ids)} accounts. Check logs for details."
             )
             logging.warning(f"Failed IDs: {failed_ids}")
-
-    def _is_user_not_found_error(self, user_id):
-        """
-        A placeholder to simulate checking for a "Not Found" error condition.
-        In a real implementation, the XService would provide a clearer status.
-        """
-        # This is a simplification. We assume that if the user_details is None,
-        # and we can't find them again, they are "not found".
-        return True

--- a/src/x_agent/cli.py
+++ b/src/x_agent/cli.py
@@ -19,18 +19,18 @@ class SingleLineUpdateHandler(logging.StreamHandler):
             if self._last_single_line_length > len(message):
                 print(
                     " " * self._last_single_line_length,
-                    end="\\r",
+                    end="\r",
                     file=sys.stdout,
                     flush=True,
                 )
-            print(f"\\r{message}", end="", file=sys.stdout, flush=True)
+            print(f"\r{message}", end="", file=sys.stdout, flush=True)
             self._last_single_line_length = len(message)
         else:
             # If a non-single-line record comes, clear any active single-line message
             if self._last_single_line_length > 0:
                 print(
                     " " * self._last_single_line_length,
-                    end="\\r",
+                    end="\r",
                     file=sys.stdout,
                     flush=True,
                 )


### PR DESCRIPTION
This commit addresses two issues identified during review:

1.  Corrects the escaped carriage return `\r` to `\r` in the `SingleLineUpdateHandler` to ensure the single-line logging functions as intended.
2.  Removes the unused and obsolete `_is_user_not_found_error` placeholder method from the `UnblockAgent`.