### PR TITLE
Zombie Block Recovery Implementation

### DIFF
--- a/src/x_agent/services/x_service.py
+++ b/src/x_agent/services/x_service.py
@@ -158,23 +158,38 @@ class XService:
             logging.warning(f"Error checking existence of user {user_id}: {e}")
             return None
 
+    async def _user_exists(self, user_id: int) -> bool | None:
+        """Checks if a user exists and is active using v2 API with v1 fallback."""
+        try:
+            response = await self.client.get_user(id=user_id)
+            if response and response.data:
+                return True
+            # V2 can return success but with errors for specific IDs
+            if response and response.errors:
+                for error in response.errors:
+                    if "Could not find user with id" in error.get("detail", ""):
+                        return False
+            return False
+        except tweepy.errors.NotFound:
+            return False
+        except Exception as e:
+            logging.debug(
+                f"V2 existence check failed for {user_id}: {e}. Falling back to V1."
+            )
+            return await self._check_user_exists_v1(user_id)
+
     async def _handle_zombie_recovery(self, user_id: int) -> str:
         """
         Attempts to fix a 'Zombie Block'.
         """
-        logging.warning(
+        logging.info(
             f"User ID {user_id} EXISTS. Attempting recovery strategies (Zombie Fix)..."
         )
 
         # Strategy 1: V2 Unblock
         try:
             await self.ensure_initialized()
-            await self.client.request(
-                "DELETE",
-                f"/2/users/{self.user_id}/blocking/{user_id}",
-                params={},
-                user_auth=True,
-            )
+            await self.client.unblock(id=self.user_id, target_user_id=user_id)
             return "SUCCESS"
         except tweepy.errors.NotFound as e:
             logging.warning(
@@ -188,14 +203,23 @@ class XService:
             else:
                 logging.warning(f"V2 Unblock failed for {user_id}: {e}")
 
-        # Strategy 2: Toggle Block Fix
+        # Strategy 2: V1 Toggle Block Fix
         try:
             async with self.v1_lock:
                 await asyncio.to_thread(self.api_v1.create_block, user_id=user_id)
                 await asyncio.to_thread(self.api_v1.destroy_block, user_id=user_id)
             return "SUCCESS"
         except Exception as e:
-            logging.warning(f"Toggle Block Fix failed for {user_id}: {e}")
+            logging.warning(f"V1 Toggle Block Fix failed for {user_id}: {e}")
+
+        # Strategy 3: V2 Toggle Block Fix
+        try:
+            await self.ensure_initialized()
+            await self.client.block(id=self.user_id, target_user_id=user_id)
+            await self.client.unblock(id=self.user_id, target_user_id=user_id)
+            return "SUCCESS"
+        except Exception as e:
+            logging.warning(f"V2 Toggle Block Fix failed for {user_id}: {e}")
 
         logging.warning(
             f"All recovery strategies failed for {user_id} (True Zombie Block). Skipping to avoid infinite retries."
@@ -218,23 +242,21 @@ class XService:
                 await asyncio.to_thread(self.api_v1.destroy_block, user_id=user_id)
             return "SUCCESS"
         except tweepy.errors.NotFound as e:
-            # Not found is not transient, so we handle it immediately
-            logging.warning(
-                f"User ID {user_id} not found (404) on V1. API says: {e}. Checking if user exists..."
+            # They might exist but the block relationship is glitched
+            logging.debug(
+                f"User {user_id} unblock failed with NotFound. Checking if user exists..."
             )
-            exists = await self._check_user_exists_v1(user_id)
-            if exists is True:
-                return await self._handle_zombie_recovery(user_id)
-            elif exists is False:
-                logging.warning(
-                    f"User ID {user_id} confirmed missing. Skipping (Ghost Block)."
-                )
+            exists = await self._user_exists(user_id)
+            if exists is False:
+                logging.debug(f"User {user_id} does not exist. Ignoring NotFound.")
                 return "NOT_FOUND"
-            else:  # exists is None
+            elif exists is None:
                 logging.warning(
                     f"Could not verify existence of {user_id}. Returning FAILED to retry later."
                 )
                 return "FAILED"
+
+            return await self._handle_zombie_recovery(user_id)
         except Exception as e:
             if is_transient_error(e):
                 raise  # Reraise to let tenacity handle it

--- a/tests/test_x_service.py
+++ b/tests/test_x_service.py
@@ -23,6 +23,9 @@ def mock_async_client():
     client.get_me = AsyncMock(
         return_value=MagicMock(data=MagicMock(id=12345, username="testuser"))
     )
+    client.get_user = AsyncMock()
+    client.unblock = AsyncMock()
+    client.block = AsyncMock()
     client.request = AsyncMock()
     # Mocking session for close()
     client.session = MagicMock()
@@ -114,15 +117,13 @@ async def test_unblock_user_zombie_fixed_v2(x_service, mock_api_v1, mock_async_c
     mock_api_v1.destroy_block.side_effect = [
         tweepy.errors.NotFound(MagicMock()),  # Initial try
     ]
-    mock_api_v1.get_user.return_value = MagicMock()  # User exists
-    mock_async_client.request.return_value = MagicMock()  # V2 success
+    mock_async_client.get_user.return_value = MagicMock(data=MagicMock())  # User exists
+    mock_async_client.unblock.return_value = MagicMock()  # V2 success
 
     result = await x_service.unblock_user(999)
 
     assert result == "SUCCESS"
-    mock_async_client.request.assert_awaited_once_with(
-        "DELETE", "/2/users/12345/blocking/999", params={}, user_auth=True
-    )
+    mock_async_client.unblock.assert_awaited_once_with(id=12345, target_user_id=999)
 
 
 @pytest.mark.asyncio
@@ -135,8 +136,8 @@ async def test_unblock_user_zombie_fixed_toggle(
         tweepy.errors.NotFound(MagicMock()),  # Initial try
         MagicMock(),  # Destroy block in toggle success
     ]
-    mock_api_v1.get_user.return_value = MagicMock()  # User exists
-    mock_async_client.request.side_effect = tweepy.errors.NotFound(
+    mock_async_client.get_user.return_value = MagicMock(data=MagicMock())  # User exists
+    mock_async_client.unblock.side_effect = tweepy.errors.NotFound(
         MagicMock()
     )  # V2 fail
     mock_api_v1.create_block.return_value = MagicMock()  # Toggle success
@@ -144,10 +145,30 @@ async def test_unblock_user_zombie_fixed_toggle(
     result = await x_service.unblock_user(999)
 
     assert result == "SUCCESS"
-    mock_async_client.request.assert_awaited_once_with(
-        "DELETE", "/2/users/12345/blocking/999", params={}, user_auth=True
-    )
+    mock_async_client.unblock.assert_awaited_with(id=12345, target_user_id=999)
     mock_api_v1.create_block.assert_called_once_with(user_id=999)
+
+
+@pytest.mark.asyncio
+async def test_unblock_user_zombie_v2_toggle(x_service, mock_api_v1, mock_async_client):
+    """Test unblock_user handles Zombie Block using V2 Toggle fix."""
+    x_service.user_id = 12345
+    mock_api_v1.destroy_block.side_effect = [
+        tweepy.errors.NotFound(MagicMock()),  # Initial try
+    ]
+    mock_async_client.get_user.return_value = MagicMock(data=MagicMock())  # User exists
+    mock_async_client.unblock.side_effect = [
+        tweepy.errors.NotFound(MagicMock()),  # Strategy 1 fail
+        MagicMock(),  # Strategy 3 unblock success
+    ]
+    mock_api_v1.create_block.side_effect = Exception("V1 fail")  # Strategy 2 fail
+    mock_async_client.block.return_value = MagicMock()  # Strategy 3 block success
+
+    result = await x_service.unblock_user(999)
+
+    assert result == "SUCCESS"
+    assert mock_async_client.unblock.await_count == 2
+    mock_async_client.block.assert_awaited_once_with(id=12345, target_user_id=999)
 
 
 @pytest.mark.asyncio
@@ -159,10 +180,10 @@ async def test_unblock_user_zombie_v2_json_error(
     mock_api_v1.destroy_block.side_effect = [
         tweepy.errors.NotFound(MagicMock()),  # Initial try
     ]
-    mock_api_v1.get_user.return_value = MagicMock()  # User exists
+    mock_async_client.get_user.return_value = MagicMock(data=MagicMock())  # User exists
 
     # Simulate the specific JSON decode error from Tweepy/simplejson
-    mock_async_client.request.side_effect = Exception(
+    mock_async_client.unblock.side_effect = Exception(
         "Attempt to decode JSON with unexpected mimetype: text/html;charset=utf-8"
     )
 
@@ -177,8 +198,47 @@ async def test_unblock_user_zombie_v2_json_error(
 
     # It succeeds because Strategy 2 works
     assert result == "SUCCESS"
-    mock_async_client.request.assert_awaited_once()
+    mock_async_client.unblock.assert_awaited_once()
     mock_api_v1.create_block.assert_called_once_with(user_id=999)
+
+
+@pytest.mark.asyncio
+async def test_user_exists_v2_success(x_service, mock_async_client):
+    """Test _user_exists returns True if V2 finds user."""
+    mock_async_client.get_user.return_value = MagicMock(data=MagicMock())
+    assert await x_service._user_exists(999) is True
+
+
+@pytest.mark.asyncio
+async def test_user_exists_v2_not_found_error(x_service, mock_async_client):
+    """Test _user_exists returns False if V2 returns 'Could not find user' error."""
+    mock_async_client.get_user.return_value = MagicMock(
+        data=None, errors=[{"detail": "Could not find user with id [999]."}]
+    )
+    assert await x_service._user_exists(999) is False
+
+
+@pytest.mark.asyncio
+async def test_user_exists_v2_exception_v1_fallback(
+    x_service, mock_async_client, mock_api_v1
+):
+    """Test _user_exists falls back to V1 if V2 raises exception."""
+    mock_async_client.get_user.side_effect = Exception("API Down")
+    mock_api_v1.get_user.return_value = MagicMock()
+    assert await x_service._user_exists(999) is True
+    mock_api_v1.get_user.assert_called_once_with(user_id=999)
+
+
+@pytest.mark.asyncio
+async def test_unblock_user_existence_check_failed(x_service, mock_api_v1, mock_async_client):
+    """Test unblock_user returns FAILED if existence check fails."""
+    mock_api_v1.destroy_block.side_effect = tweepy.errors.NotFound(MagicMock())
+    mock_async_client.get_user.side_effect = Exception("V2 Down")
+    mock_api_v1.get_user.side_effect = Exception("V1 Down")
+
+    result = await x_service.unblock_user(999)
+
+    assert result == "FAILED"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implemented a multi-strategy recovery mechanism for 'Zombie Blocks' in the `XService`. This scenario occurs when an unblock attempt fails with a `NotFound` (404) error despite the target user still existing on the platform.

Key changes:
- New `_user_exists` method: Prioritizes X API v2 (handling its error list format) and falls back to v1.1.
- Enhanced `_handle_zombie_recovery`:
    - Strategy 1: V2 Unblock (using `AsyncClient.unblock`).
    - Strategy 2: V1 Toggle (Block then Unblock using v1.1).
    - Strategy 3: V2 Toggle (Block then Unblock using v2).
- Refactored `unblock_user`: Now distinguishes between 'Ghost Blocks' (true 404s) and 'Zombie Blocks' (glitched relationships) to provide more reliable operation and better logging.
- Expanded test suite: Added unit tests for new methods and fallback logic.

---
*PR created automatically by Jules for task [2202691371253462216](https://jules.google.com/task/2202691371253462216) started by @rmedranollamas*