### PR TITLE
🔒 Fix SQL injection in migration

### DIFF
--- a/src/x_agent/migrations/versions/m001_initial.py
+++ b/src/x_agent/migrations/versions/m001_initial.py
@@ -70,6 +70,24 @@ class InitialSchema(Migration):
     def _ensure_column(
         self, cursor: sqlite3.Cursor, table: str, column: str, definition: str
     ):
+        # Security: Validate inputs against allowlist to prevent SQL injection
+        allowed_tables = {
+            "insights",
+            "blocked_users",
+            "following_users",
+            "followers",
+            "unfollows",
+        }
+        allowed_columns = {"tweet_count", "status", "updated_at"}
+        allowed_definitions = {"INTEGER DEFAULT 0", "TEXT DEFAULT 'PENDING'", "DATETIME"}
+
+        if table not in allowed_tables:
+            raise ValueError(f"Unauthorized table: {table}")
+        if column not in allowed_columns:
+            raise ValueError(f"Unauthorized column: {column}")
+        if definition not in allowed_definitions:
+            raise ValueError(f"Unauthorized definition: {definition}")
+
         cursor.execute(f"PRAGMA table_info({table})")
         columns = [row[1] for row in cursor.fetchall()]
         if column not in columns:

--- a/tests/test_vulnerability_m001.py
+++ b/tests/test_vulnerability_m001.py
@@ -1,0 +1,47 @@
+import sqlite3
+import pytest
+from x_agent.migrations.versions.m001_initial import InitialSchema
+
+def test_ensure_column_rejects_unauthorized_tables():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE secret_table (id INTEGER)")
+
+    migration = InitialSchema()
+
+    with pytest.raises(ValueError, match="Unauthorized table: secret_table"):
+        migration._ensure_column(cursor, "secret_table", "status", "TEXT DEFAULT 'PENDING'")
+
+def test_ensure_column_rejects_unauthorized_columns():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE insights (id INTEGER)")
+
+    migration = InitialSchema()
+
+    with pytest.raises(ValueError, match="Unauthorized column: test_col"):
+        migration._ensure_column(cursor, "insights", "test_col", "INTEGER DEFAULT 0")
+
+def test_ensure_column_rejects_unauthorized_definitions():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE insights (id INTEGER)")
+
+    migration = InitialSchema()
+
+    with pytest.raises(ValueError, match="Unauthorized definition: TEXT DEFAULT 'vulnerable'"):
+        migration._ensure_column(cursor, "insights", "status", "TEXT DEFAULT 'vulnerable'")
+
+def test_ensure_column_permits_authorized_inputs():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE insights (id INTEGER)")
+
+    migration = InitialSchema()
+
+    # This should succeed
+    migration._ensure_column(cursor, "insights", "tweet_count", "INTEGER DEFAULT 0")
+
+    cursor.execute("PRAGMA table_info(insights)")
+    cols = cursor.fetchall()
+    assert any(col[1] == "tweet_count" for col in cols)


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in the initial migration script (`src/x_agent/migrations/versions/m001_initial.py`).

⚠️ **Risk:** The `_ensure_column` method used f-strings to construct SQL queries (`PRAGMA table_info` and `ALTER TABLE ADD COLUMN`) without sanitizing input. This could potentially allow an attacker who can influence migration parameters to execute arbitrary SQL, although in practice migration parameters are typically hardcoded.

🛡️ **Solution:** Implemented allowlist validation for the `table`, `column`, and `definition` parameters in `_ensure_column`. The method now raises a `ValueError` if any parameter does not match the predefined set of expected identifiers and types. Added a new test file `tests/test_vulnerability_m001.py` to verify that unauthorized inputs are rejected and authorized ones are permitted.

---
*PR created automatically by Jules for task [8168091626969416448](https://jules.google.com/task/8168091626969416448) started by @rmedranollamas*