### PR TITLE
feat: add email support and handles reporting to UnfollowAgent

### DIFF
--- a/src/x_agent/agents/unfollow_agent.py
+++ b/src/x_agent/agents/unfollow_agent.py
@@ -33,7 +33,7 @@ class UnfollowAgent(BaseAgent):
         self.x_service = x_service
         self.dry_run = dry_run
 
-    async def execute(self) -> None:
+    async def execute(self) -> str | None:
         """
         Executes the unfollow detection logic.
         1) Gets current follower list from the API.
@@ -72,7 +72,7 @@ class UnfollowAgent(BaseAgent):
             await asyncio.to_thread(self.db.replace_followers, current_followers)
 
         # 4) Show stats and store unfollow events
-        self._report_stats(len(current_followers), unfollowed_ids, new_followers_count)
+        report = await self._report_stats(len(current_followers), unfollowed_ids, new_followers_count)
 
         if unfollowed_ids:
             if self.dry_run:
@@ -84,19 +84,34 @@ class UnfollowAgent(BaseAgent):
                 await asyncio.to_thread(self.db.log_unfollows, list(unfollowed_ids))
 
         logging.info("Unfollow detection completed.")
+        return report
 
-    def _report_stats(
+    async def _report_stats(
         self, current_total: int, unfollowed_ids: set[int], new_followers_count: int
-    ) -> None:
-        """Reports the findings to the console."""
-        print("\n--- Unfollow Detection Report ---")
-        print(f"Total Followers: {current_total}")
-        print(f"New Followers:   {new_followers_count}")
-        print(f"Unfollows:       {len(unfollowed_ids)}")
+    ) -> str:
+        """Reports the findings to the console and returns the report."""
+        lines = []
+        lines.append("\n--- Unfollow Detection Report ---")
+        lines.append(f"Total Followers: {current_total}")
+        lines.append(f"New Followers:   {new_followers_count}")
+        lines.append(f"Unfollows:       {len(unfollowed_ids)}")
 
         if unfollowed_ids:
-            print("\nIDs that unfollowed you:")
-            for uid in sorted(unfollowed_ids):
-                print(f" - {uid}")
+            lines.append("\nAccounts that unfollowed you:")
 
-        print("---------------------------------\n")
+            # Resolve handles
+            unfollowed_users = await self.x_service.get_users_by_ids(list(unfollowed_ids))
+            user_map = {u.id: u.username for u in unfollowed_users}
+
+            for uid in sorted(unfollowed_ids):
+                handle = user_map.get(uid)
+                if handle:
+                    lines.append(f" - @{handle} (ID: {uid})")
+                else:
+                    lines.append(f" - {uid}")
+
+        lines.append("---------------------------------\n")
+
+        report_text = "\n".join(lines)
+        print(report_text)
+        return report_text

--- a/src/x_agent/cli.py
+++ b/src/x_agent/cli.py
@@ -151,11 +151,20 @@ def unfollow(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Simulate actions without making changes."
     ),
+    email: bool = typer.Option(
+        False, "--email", help="Send the report via email after generation."
+    ),
 ):
     """
     Run the unfollow agent to detect who has unfollowed you.
     """
-    _run_agent(UnfollowAgent, debug, dry_run=dry_run)
+    try:
+        asyncio.run(
+            _execute_agent(UnfollowAgent, debug, email=email, dry_run=dry_run)
+        )
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}", exc_info=True)
+        sys.exit(1)
 
 
 @app.command()

--- a/tests/test_unfollow_agent.py
+++ b/tests/test_unfollow_agent.py
@@ -10,6 +10,7 @@ def mock_x_service():
     service = MagicMock(spec=XService)
     service.ensure_initialized = AsyncMock()
     service.get_follower_user_ids = AsyncMock()
+    service.get_users_by_ids = AsyncMock(return_value=[])
     return service
 
 
@@ -61,3 +62,21 @@ async def test_execute_no_changes(unfollow_agent, mock_x_service, mock_db_manage
 
     mock_db_manager.log_unfollows.assert_not_called()
     mock_db_manager.replace_followers.assert_called_once_with({101, 102})
+
+@pytest.mark.asyncio
+async def test_execute_report_handles(unfollow_agent, mock_x_service, mock_db_manager):
+    """Test that the agent resolves usernames for unfollowers and reports them."""
+    import tweepy
+    mock_x_service.get_follower_user_ids.return_value = {102, 103}
+    mock_db_manager.get_all_follower_ids.return_value = {101, 102}
+
+    user101 = MagicMock(spec=tweepy.User)
+    user101.id = 101
+    user101.username = "unfollowed_user"
+
+    mock_x_service.get_users_by_ids.return_value = [user101]
+
+    report = await unfollow_agent.execute()
+
+    assert "- @unfollowed_user (ID: 101)" in report
+    assert "Unfollows:       1" in report

--- a/tests/test_x_service.py
+++ b/tests/test_x_service.py
@@ -100,9 +100,10 @@ async def test_unblock_user_success(x_service, mock_api_v1):
 
 
 @pytest.mark.asyncio
-async def test_unblock_user_not_found(x_service, mock_api_v1):
+async def test_unblock_user_not_found(x_service, mock_api_v1, mock_async_client):
     """Test unblock_user returns NOT_FOUND on 404 if user doesn't exist."""
     mock_api_v1.destroy_block.side_effect = tweepy.errors.NotFound(MagicMock())
+    mock_async_client.get_user.side_effect = tweepy.errors.NotFound(MagicMock())
     mock_api_v1.get_user.side_effect = tweepy.errors.NotFound(MagicMock())
 
     result = await x_service.unblock_user(999)


### PR DESCRIPTION
Fixes issue where the unfollow agent only output user IDs and did not support email. This allows the user to see the Twitter handles of people who unfollowed them and receive the report via email, similar to the insights agent.

---
*PR created automatically by Jules for task [10240082555478264419](https://jules.google.com/task/10240082555478264419) started by @rmedranollamas*