### PR TITLE
Enhance CI workflow with coverage enforcement and Codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,16 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
 
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
           export X_API_KEY=dummy_api_key
           export X_API_KEY_SECRET=dummy_api_key_secret
           export X_ACCESS_TOKEN=dummy_access_token
           export X_ACCESS_TOKEN_SECRET=dummy_access_token_secret
-          uv run pytest tests/ -v
+          uv run pytest tests/ -v --cov=src --cov-report=xml --cov-report=html --cov-fail-under=80
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Enhanced CI workflow with coverage enforcement and Codecov integration

## Changes
- Added --cov-fail-under=80 to enforce minimum 80% test coverage threshold
- Generate coverage reports in XML (for Codecov) and HTML formats
- Added Codecov upload step to track coverage trends over time
- Current coverage: 82.63% (passes threshold)

## Verification
- All 137 tests pass
- Coverage threshold of 80% is met (82.63%)
- Coverage XML and HTML reports generated successfully

Closes #70