### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rmedranollamas/x/security/code-scanning/1](https://github.com/rmedranollamas/x/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained instead of inheriting defaults.

Best single fix (without changing functionality): add a root-level permissions block with `contents: read` right after the `on` section (before `jobs`). This satisfies checkout needs and follows least privilege. If future steps need extra scopes, they can be added explicitly later.

File to change: `.github/workflows/test.yml`  
Region: between lines 7 and 9 (after trigger config, before `jobs:`).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
