### PR TITLE
feat: resolve usernames for deactivated/suspended accounts via v1 api fallback

### DIFF
--- a/src/x_agent/agents/insights_agent.py
+++ b/src/x_agent/agents/insights_agent.py
@@ -68,6 +68,9 @@ class InsightsAgent(BaseAgent):
         new_ids = []
         lost_ids = []
 
+        new_user_map: dict[int, str] = {}
+        lost_user_map: dict[int, str] = {}
+
         if previous_follower_ids:
             new_ids = list(current_follower_ids - previous_follower_ids)
             lost_ids = list(previous_follower_ids - current_follower_ids)
@@ -75,10 +78,18 @@ class InsightsAgent(BaseAgent):
             if new_ids:
                 logging.info(f"Resolving {len(new_ids)} new follower usernames...")
                 new_follower_users = await self.x_service.get_users_by_ids(new_ids)
+                new_user_map = {int(u.id): u.username for u in new_follower_users}
+                for uid in new_ids:
+                    if uid not in new_user_map:
+                        new_user_map[uid] = await self.x_service.resolve_user_fallback(uid)
 
             if lost_ids:
                 logging.info(f"Resolving {len(lost_ids)} lost follower usernames...")
                 lost_follower_users = await self.x_service.get_users_by_ids(lost_ids)
+                lost_user_map = {int(u.id): u.username for u in lost_follower_users}
+                for uid in lost_ids:
+                    if uid not in lost_user_map:
+                        lost_user_map[uid] = await self.x_service.resolve_user_fallback(uid)
 
         # Update follower list in DB
         await asyncio.to_thread(self.db.replace_followers, current_follower_ids)
@@ -99,8 +110,8 @@ class InsightsAgent(BaseAgent):
             current_listed_count,
             created_at,
             comparisons,
-            new_follower_users,
-            lost_follower_users,
+            new_user_map,
+            lost_user_map,
             new_ids,
             lost_ids,
         )
@@ -128,8 +139,8 @@ class InsightsAgent(BaseAgent):
         current_listed: int,
         created_at: Optional[Union[datetime, time.struct_time]],
         comparisons: dict[str, Optional[sqlite3.Row]],
-        new_followers: list[tweepy.User],
-        lost_followers: list[tweepy.User],
+        new_user_map: dict[int, str],
+        lost_user_map: dict[int, str],
         new_ids: list[int],
         lost_ids: list[int],
     ) -> str:
@@ -155,15 +166,15 @@ class InsightsAgent(BaseAgent):
         if new_ids or lost_ids:
             lines.append("           FOLLOWERS LOG")
 
-            new_user_map = {int(u.id): u.username for u in new_followers}
-            lost_user_map = {int(u.id): u.username for u in lost_followers}
-
             if new_ids:
                 lines.append(f"New ({len(new_ids)}):")
                 for uid in sorted(new_ids):
                     handle = new_user_map.get(int(uid))
                     if handle:
-                        lines.append(f" + @{handle}")
+                        if handle.startswith("("):
+                            lines.append(f" + ID: {uid} {handle}")
+                        else:
+                            lines.append(f" + @{handle}")
                     else:
                         lines.append(f" + ID: {uid}")
             if lost_ids:
@@ -171,7 +182,10 @@ class InsightsAgent(BaseAgent):
                 for uid in sorted(lost_ids):
                     handle = lost_user_map.get(int(uid))
                     if handle:
-                        lines.append(f" - @{handle}")
+                        if handle.startswith("("):
+                            lines.append(f" - ID: {uid} {handle}")
+                        else:
+                            lines.append(f" - @{handle}")
                     else:
                         lines.append(f" - ID: {uid}")
             lines.append("-" * width)

--- a/src/x_agent/agents/unfollow_agent.py
+++ b/src/x_agent/agents/unfollow_agent.py
@@ -103,10 +103,17 @@ class UnfollowAgent(BaseAgent):
             unfollowed_users = await self.x_service.get_users_by_ids(list(unfollowed_ids))
             user_map = {int(u.id): u.username for u in unfollowed_users}
 
+            for uid in unfollowed_ids:
+                if uid not in user_map:
+                    user_map[uid] = await self.x_service.resolve_user_fallback(uid)
+
             for uid in sorted(unfollowed_ids):
                 handle = user_map.get(int(uid))
                 if handle:
-                    lines.append(f" - @{handle} (ID: {uid})")
+                    if handle.startswith("("):
+                        lines.append(f" - ID: {uid} {handle}")
+                    else:
+                        lines.append(f" - @{handle} (ID: {uid})")
                 else:
                     lines.append(f" - {uid}")
 

--- a/src/x_agent/services/x_service.py
+++ b/src/x_agent/services/x_service.py
@@ -416,6 +416,28 @@ class XService:
         retry=retry_if_exception(is_transient_error),
         reraise=True,
     )
+    async def resolve_user_fallback(self, user_id: int) -> str:
+        """Attempts to resolve a user's screen name via V1 API, or returns their status."""
+        try:
+            async with self.v1_lock:
+                user = await asyncio.to_thread(self.api_v1.get_user, user_id=user_id)
+                return user.screen_name
+        except tweepy.errors.NotFound:
+            return "(Deactivated)"
+        except tweepy.errors.Forbidden:
+            return "(Suspended)"
+        except Exception as e:
+            if is_transient_error(e):
+                raise
+            logging.warning(f"Fallback resolution failed for {user_id}: {e}")
+            return "(Unknown)"
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        retry=retry_if_exception(is_transient_error),
+        reraise=True,
+    )
     async def get_users_by_ids(self, user_ids: list[int]) -> list[tweepy.User]:
         """
         Resolves a list of user IDs to user objects using the v2 API.


### PR DESCRIPTION
This commit adds a fallback mechanism to explicitly resolve User IDs that are silently dropped by the X API v2 (usually when users are suspended or deactivated). This solves an issue where followers logs output bare numerical IDs instead of user handles. By falling back to v1.1 API lookup for any missing IDs, the code retrieves the user's handle if available or neatly formats their status if missing.

---
*PR created automatically by Jules for task [16513060142616552434](https://jules.google.com/task/16513060142616552434) started by @rmedranollamas*